### PR TITLE
fix(nextcloudignore): do not exclude CHANGELOG.md from release archive

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -17,7 +17,6 @@
 /build
 /APPS.md
 /AUTHORS.md
-/CHANGELOG.md
 /HOW_TO_INSTALL.md
 /README.md
 /composer.*


### PR DESCRIPTION
Do not exclude `CHANGELOG.md` file from the release archive. AppStore uses it to provide last release changelog in API and is used by Nextcloud Apps management UI.